### PR TITLE
Added encoding header in comments to remove setup error in setup.py:

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can find out more about these two methods in our [API documentation](https:/
 
 ## Interacting with the Uphold Sandbox
 
-The [Uphold Sandbox](https://developer.uphold.com/en/sandbox) is a test environment for developers to build and test their apps. The Sandbox environment uses fake money, but is otherwise an exact copy of our production system. 
+The [Uphold Sandbox](https://uphold.com/en/developer/sandbox) is a test environment for developers to build and test their apps. The Sandbox environment uses fake money, but is otherwise an exact copy of our production system. 
 
     from uphold import Uphold
     api = Uphold(host='api-sandbox.uphold.com')

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from distutils.core import setup
 setup(
   name = 'uphold',


### PR DESCRIPTION
Without the encoding tag, the following error is returned on executing setup script:

SyntaxError: Non-ASCII character '\xc3' in file setup.py

(Tried on Python 2.7)